### PR TITLE
Add support for buffer-local mappings.

### DIFF
--- a/lua/better-n/init.lua
+++ b/lua/better-n/init.lua
@@ -133,5 +133,6 @@ end
 return {
   setup = setup,
   n = n,
+  register_keys = register_keys,
   shift_n = shift_n,
 }


### PR DESCRIPTION
This now causes `better-n` to run every time you load a new buffer,
applying after other autocmds might have mapped some new keys for the
specific buffer. Notable examples include `nvim-treesitter-textobjects`.

Fixes https://github.com/jonatan-branting/nvim-better-n/issues/3