### PR TITLE
Fix interaction with macros and `normal`

### DIFF
--- a/lua/better-n/init.lua
+++ b/lua/better-n/init.lua
@@ -20,7 +20,7 @@ local mappings_table = {
 }
 
 local execute_map = function(map)
-  vim.api.nvim_feedkeys(utils.t(vim.v.count1 .. mapping_prefix .. map), vim.fn.mode(), false)
+  vim.api.nvim_input(vim.v.count1 .. mapping_prefix .. map)
 end
 
 local n = function()
@@ -84,7 +84,7 @@ local remap_key = function(bufnr, mode, key)
   vim.keymap.set(mode, key, function()
     autocmd.emit("MappingExecuted", mode, key)
 
-    vim.api.nvim_feedkeys(utils.t(vim.v.count1 .. mapping_prefix .. key), mode, false)
+    vim.api.nvim_input(vim.v.count1 .. mapping_prefix .. key)
   end, { silent = true, buffer = bufnr, desc = "better_n_remap" })
 end
 

--- a/lua/better-n/init.lua
+++ b/lua/better-n/init.lua
@@ -19,6 +19,9 @@ M.mappings_table = {
 	["?"] = { previous = "<s-n>", next = "n", cmdline = true },
 }
 
+vim.keymap.set({ "n", "x" }, "<Plug>(better-n)n", "n")
+vim.keymap.set({ "n", "x" }, "<Plug>(better-n)sn", "<s-n>")
+
 function M.execute_map(map)
 	-- TODO do not assume it's bound to n/<s-n>
 	if map == "n" or map == "<s-n>" then
@@ -29,11 +32,25 @@ function M.execute_map(map)
 end
 
 function M.n()
-	M.execute_map(M.mappings_table[M.latest_movement_cmd.key].next)
+	local key = M.mappings_table[M.latest_movement_cmd.key].next
+	if key == "n" then
+		return "<Plug>(better-n)n"
+	elseif key == "<s-n>" then
+		return "<Plug>(better-n)sn"
+	else
+		return key
+	end
 end
 
 function M.shift_n()
-	M.execute_map(M.mappings_table[M.latest_movement_cmd.key].previous)
+	local key = M.mappings_table[M.latest_movement_cmd.key].previous
+	if key == "n" then
+		return "<Plug>(better-n)n"
+	elseif key == "<s-n>" then
+		return "<Plug>(better-n)sn"
+	else
+		return key
+	end
 end
 
 function M.setup_autocmds(callback)


### PR DESCRIPTION
Before this, we used `feedkeys`, which inputs keys into the typeahead buffer <https://stackoverflow.com/questions/47780122/force-feedkeys-to-paste-characters-immediately/47789099#47789099>. This buffer was not consumed during a macro, which I think might've caused the issues described in issue [6](https://github.com/jonatan-branting/nvim-better-n/issues/6).

We're instead using `nvim_input`, which instead queues raw user input. This is however non-blocking, which might cause other issues.