### PR TITLE
Fix issue with key-less repeatables overwriting eachother

### DIFF
--- a/lua/better-n/register.lua
+++ b/lua/better-n/register.lua
@@ -68,7 +68,17 @@ function Register:previous()
 end
 
 function Register:_generate_key()
-	return "<Plug>(Register)#" .. #self.repeatables
+	return "<Plug>(Register)#" .. self:_num_repeatables()
+end
+
+-- Workaround for # only working for array-based tables
+function Register:_num_repeatables()
+	local count = 0
+	for _ in pairs(self.repeatables) do
+		count = count + 1
+	end
+
+	return count
 end
 
 return Register


### PR DESCRIPTION
TIL that`#` apparently only returns the length of the array part of a table!

This caused issues where repeatables created without a specified `key` would overwrite eachother.