### PR TITLE
Allow using `<Plug>` mappings

### DIFF
--- a/lua/better-n/register.lua
+++ b/lua/better-n/register.lua
@@ -48,6 +48,10 @@ function Register:create(opts)
     id = opts.id,
   })
 
+  vim.keymap.set(repeatable.mode, repeatable.passthrough_key, repeatable.passthrough, { expr = true, silent = true })
+  vim.keymap.set(repeatable.mode, repeatable.next_key, repeatable.next, { expr = true, silent = true })
+  vim.keymap.set(repeatable.mode, repeatable.previous_key, repeatable.previous, { expr = true, silent = true })
+
   self.repeatables[repeatable.id] = repeatable
 
   return repeatable


### PR DESCRIPTION
Allow using `<Plug>` mappings instead of having to rely on `expr` mappings.

These mappings can be used through the `_key` suffix, like this:
```lua
vim.keymap.set("n", "]]", repeatable.next_key)
```